### PR TITLE
Update minion.erb

### DIFF
--- a/templates/minion.erb
+++ b/templates/minion.erb
@@ -15,7 +15,7 @@
 # resolved, then the minion will fail to start.
 <% if @minion_master.kind_of?(Array) -%>
 master:
-<% minion_master.each do |mstr|  -%>
+<% @minion_master.each do |mstr|  -%>
   - <%= mstr %>
 <% end -%>
 <% else -%>


### PR DESCRIPTION
Fixing variable scope in minion template.  Current use yields in warnings: "Warning: Variable access via 'minion_master' is deprecated. Use '@minion_master' instead. template[/etc/puppet/modules/salt/templates/minion.erb]:18"