### PR TITLE
adding ability to configure minion/master key verification

### DIFF
--- a/manifests/minion.pp
+++ b/manifests/minion.pp
@@ -73,6 +73,7 @@ class salt::minion (
   $minion_state_verbose   = $salt::params::minion_state_verbose,
   $minion_state_output    = $salt::params::minion_state_output,
   $minion_master_finger   = $salt::params::minion_master_finger,
+  $minion_verify_master_pubkey_sign  = $salt::params::minion_verify_master_pubkey_sign,
   # minion thread settings
   $minion_multiprocessing = $salt::params::minion_multiprocessing,
   # minion logging settings

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -237,6 +237,7 @@ class salt::params {
   $minion_state_verbose = true
   $minion_state_output = 'full'
   $minion_master_finger = ''
+  $minion_verify_master_pubkey_sign = false
 
   # minion thread settings
   $minion_multiprocessing = true

--- a/templates/minion.erb
+++ b/templates/minion.erb
@@ -498,6 +498,9 @@ state_output_diff: <%= @minion_state_output_diff %>
 # salt master.
 master_finger: <%= @minion_master_finger %>
 
+# Enables verification of the master-public-signature returned by the master
+# in auth-replies.
+verify_master_pubkey_sign: <%= @minion_verify_master_pubkey_sign %>
 
 ######         Thread settings        #####
 ###########################################


### PR DESCRIPTION
This change allows for the minion to be configured properly to accept and verify the master's public key if the master is providing one. This feature was introduced in version 2014.7.0. Documentation can be referenced here: https://docs.saltstack.com/en/latest/ref/configuration/minion.html